### PR TITLE
Remove dependency on PHPUnit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,7 @@
     "require": {
         "php": "^8.0",
         "ext-dom": "*",
-        "codeception/lib-web": "^1.0",
-        "phpunit/phpunit": "^9.5 | ^10.0",
+        "codeception/lib-web": "^1.0.6",
         "symfony/css-selector": ">=4.4.24 <8.0"
     },
     "conflict": {


### PR DESCRIPTION
PHPUnit is indirect dependency
[ElementNotFound](https://github.com/Codeception/lib-web/blob/01ff7f9ed8760ba0b0805a0b3a843b4e74165a60/src/Exception/ElementNotFound.php) declared in codeception/lib-web extends PHPUnit\Framework\AssertionFailedError;

Closes #1